### PR TITLE
Install fcrepo-camel-service to avoid java-client errors

### DIFF
--- a/install_scripts/fedora_camel_toolbox.script
+++ b/install_scripts/fedora_camel_toolbox.script
@@ -2,6 +2,7 @@ feature:repo-add mvn:org.apache.activemq/activemq-karaf/5.14.1/xml/features
 feature:repo-add mvn:org.apache.camel.karaf/apache-camel/2.20.0/xml/features
 feature:repo-add mvn:org.fcrepo.camel/toolbox-features/5.0.0-SNAPSHOT/xml/features
 feature:install fcrepo-service-activemq
+feature:install fcrepo-service-camel
 feature:install fcrepo-ldpath
 feature:install fcrepo-fixity
 feature:install fcrepo-indexing-solr


### PR DESCRIPTION
Install `fcrepo-camel-service` which resolves `fcrepo-camel` and (I am guessing) `fcrepo-java-client`

@dbernstein 
